### PR TITLE
Undo and redo all mutations in an actionGroup together

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "build": "rimraf ./dist && webpack --optimize-minimize --config ./webpack.config.js",
-    "test": "ENV=test ava ./test/test.js ./test/test-non-namespaced.js ./test/test-multiple-undo.js",
+    "test": "ENV=test ava ./test/test.js ./test/test-non-namespaced.js ./test/test-multiple-undo.js, ./test/test-action-group-undo.js",
     "doc-to-markdown": "jsdoc2md ./src/undoRedo.js"
   }
 }

--- a/src/undoRedo.js
+++ b/src/undoRedo.js
@@ -190,7 +190,7 @@ export default (options = {}) => store => {
 
       config.newMutation = false;
       // NB: The array of redoCallbacks and respective action payloads
-      const redoCallbacks = commits.map(async ({ type, payload }) => {
+      const redoCallbacks = commits.map(({ type, payload }) => {
         // NB: Commit each mutation in the redo stack
         store.commit(
           type,
@@ -205,7 +205,7 @@ export default (options = {}) => store => {
           payload,
         };
       });
-      await pipeActions(await Promise.all(redoCallbacks));
+      await pipeActions(redoCallbacks);
       config.done = [...config.done, ...commits];
       config.newMutation = true;
       setConfig(namespace, {
@@ -268,7 +268,7 @@ export default (options = {}) => store => {
       undone = [...undone, ...commits];
       config.newMutation = false;
       store.commit(`${namespace}${EMPTY_STATE}`);
-      const redoCallbacks = done.map(async mutation => {
+      const redoCallbacks = done.map(mutation => {
         store.commit(
           mutation.type,
           Array.isArray(mutation.payload)
@@ -283,7 +283,7 @@ export default (options = {}) => store => {
           payload: mutation.payload,
         };
       });
-      await pipeActions(await Promise.all(redoCallbacks));
+      await pipeActions(redoCallbacks);
       config.newMutation = true;
       setConfig(namespace, {
         ...config,

--- a/test/test-action-group-undo.js
+++ b/test/test-action-group-undo.js
@@ -1,0 +1,55 @@
+import test from 'ava';
+import Vue from 'vue';
+import plain from 'vue-plain';
+import store from './store-non-namespaced';
+
+// Get plain objects from vue/vuex getter/setter objects (https://github.com/Coffcer/vue-plain)
+Vue.use(plain);
+
+const item = {
+  foo: 'bar',
+};
+
+test.serial('Add 4 items to list', async t => {
+  const expectedState = [{ ...item }, { ...item }, { ...item }, { ...item }];
+
+  // Commit the items with action groups to the store and assert
+  await store.commit('addItem', { item });
+  await store.commit('addItem', { item, actionGroup: 'firstGroup' });
+  await store.commit('addItem', { item, actionGroup: 'firstGroup' });
+  await store.commit('addItem', { item, actionGroup: 'secondGroup' });
+  t.deepEqual(Vue.plain(store.state.list), expectedState);
+});
+
+test.serial('Undo secondGroup', async t => {
+  await store.dispatch('undo');
+  t.deepEqual(Vue.plain(store.state.list), [
+    { ...item },
+    { ...item },
+    { ...item },
+  ]);
+});
+
+test.serial('Undo firstGroup', async t => {
+  await store.dispatch('undo');
+  t.deepEqual(Vue.plain(store.state.list), [{ ...item }]);
+});
+
+test.serial('Redo firstGroup', async t => {
+  await store.dispatch('redo');
+  t.deepEqual(Vue.plain(store.state.list), [
+    { ...item },
+    { ...item },
+    { ...item },
+  ]);
+});
+
+test.serial('Redo secondGroup', async t => {
+  await store.dispatch('redo');
+  t.deepEqual(Vue.plain(store.state.list), [
+    { ...item },
+    { ...item },
+    { ...item },
+    { ...item },
+  ]);
+});

--- a/test/test-action-group-undo.js
+++ b/test/test-action-group-undo.js
@@ -6,50 +6,107 @@ import store from './store-non-namespaced';
 // Get plain objects from vue/vuex getter/setter objects (https://github.com/Coffcer/vue-plain)
 Vue.use(plain);
 
-const item = {
-  foo: 'bar',
-};
+const redo = () => store.dispatch('redo');
+const undo = () => store.dispatch('undo');
 
-test.serial('Add 4 items to list', async t => {
-  const expectedState = [{ ...item }, { ...item }, { ...item }, { ...item }];
+const item = (id, label) => ({ id, label });
+const firstGroupItems = [
+  item(0, 'First group item one'),
+  item(1, 'First group item two'),
+];
 
+const itemWithoutGroup = item(2, 'Item without group');
+
+const secondGroupItems = [
+  item(3, 'Second group item one'),
+  item(4, 'Second group item two'),
+  item(5, 'Second group item three'),
+];
+
+test.serial('Add all items', async t => {
   // Commit the items with action groups to the store and assert
-  await store.commit('addItem', { item });
-  await store.commit('addItem', { item, actionGroup: 'firstGroup' });
-  await store.commit('addItem', { item, actionGroup: 'firstGroup' });
-  await store.commit('addItem', { item, actionGroup: 'secondGroup' });
-  t.deepEqual(Vue.plain(store.state.list), expectedState);
+  await store.commit('addItem', {
+    item: firstGroupItems[0],
+    actionGroup: 'firstGroup',
+  });
+  await store.commit('addItem', {
+    item: firstGroupItems[1],
+    actionGroup: 'firstGroup',
+  });
+  await store.commit('addItem', { item: itemWithoutGroup }); // no group here
+  await store.commit('addItem', {
+    item: secondGroupItems[0],
+    actionGroup: 'secondGroup',
+  });
+  await store.commit('addItem', {
+    item: secondGroupItems[1],
+    actionGroup: 'secondGroup',
+  });
+  await store.commit('addItem', {
+    item: secondGroupItems[2],
+    actionGroup: 'secondGroup',
+  });
+
+  t.deepEqual(Vue.plain(store.state.list), [
+    ...firstGroupItems,
+    itemWithoutGroup,
+    ...secondGroupItems,
+  ]);
+});
+
+test.serial('Undo secondGroup should remove all secondGroup items', async t => {
+  await undo();
+  t.deepEqual(Vue.plain(store.state.list), [
+    ...firstGroupItems,
+    itemWithoutGroup,
+  ]);
+});
+
+test.serial('Redo secondGroup should restore full list', async t => {
+  await redo();
+  t.deepEqual(Vue.plain(store.state.list), [
+    ...firstGroupItems,
+    itemWithoutGroup,
+    ...secondGroupItems,
+  ]);
 });
 
 test.serial('Undo secondGroup', async t => {
-  await store.dispatch('undo');
+  await undo();
   t.deepEqual(Vue.plain(store.state.list), [
-    { ...item },
-    { ...item },
-    { ...item },
+    ...firstGroupItems,
+    itemWithoutGroup,
   ]);
 });
 
-test.serial('Undo firstGroup', async t => {
-  await store.dispatch('undo');
-  t.deepEqual(Vue.plain(store.state.list), [{ ...item }]);
+test.serial('Undo secondGroup and mutation without group', async t => {
+  await undo();
+  t.deepEqual(Vue.plain(store.state.list), firstGroupItems);
 });
 
-test.serial('Redo firstGroup', async t => {
-  await store.dispatch('redo');
+test.serial('Undo firstGroup as well should leave list empty', async t => {
+  await undo();
+  t.deepEqual(Vue.plain(store.state.list), []);
+});
+
+test.serial('Redo firstGroup should restore items from firstGroup', async t => {
+  await redo();
+  t.deepEqual(Vue.plain(store.state.list), firstGroupItems);
+});
+
+test.serial('Redo mutation without group should restore that item', async t => {
+  await redo();
   t.deepEqual(Vue.plain(store.state.list), [
-    { ...item },
-    { ...item },
-    { ...item },
+    ...firstGroupItems,
+    itemWithoutGroup,
   ]);
 });
 
-test.serial('Redo secondGroup', async t => {
-  await store.dispatch('redo');
+test.serial('Redo secondGroup should restore full list again', async t => {
+  await redo();
   t.deepEqual(Vue.plain(store.state.list), [
-    { ...item },
-    { ...item },
-    { ...item },
-    { ...item },
+    ...firstGroupItems,
+    itemWithoutGroup,
+    ...secondGroupItems,
   ]);
 });


### PR DESCRIPTION
What is still unclear is whether the undo-redo plugin is allowed to change the order of mutations (I guess not). Right now *all* mutations in the done and redo stack are grouped whether or not other mutation come between them in the stack.

Note: I also removed some unnecessary use of async functions.
