### PR TITLE
handle nested modules more than one level deep

### DIFF
--- a/src/undoRedo.ts
+++ b/src/undoRedo.ts
@@ -92,6 +92,12 @@ const canUndo = (paths: UndoRedoOptions[]) => (namespace: string) => {
   return false;
 };
 
+const getNamespace = (typeAttr: String) => {
+  let parts = typeAttr.split("/");
+  parts.pop();
+  return parts.join("/") + "/";
+};
+
 /**
  * The Undo-Redo plugin module
  *
@@ -117,9 +123,7 @@ export default (options: UndoRedoOptions = {}) => (store: any) => {
 
   store.subscribe((mutation: Mutation) => {
     const isStoreNamespaced = mutation.type.split("/").length > 1;
-    const namespace = isStoreNamespaced
-      ? `${mutation.type.split("/")[0]}/`
-      : "";
+    const namespace = isStoreNamespaced ? getNamespace(mutation.type) : "";
     const config = getConfig(paths)(namespace);
 
     if (Object.keys(config).length) {
@@ -145,7 +149,7 @@ export default (options: UndoRedoOptions = {}) => (store: any) => {
   // NB: Watch all actions to intercept the undo/redo NOOP actions
   store.subscribeAction(async (action: Action) => {
     const isStoreNamespaced = action.type.split("/").length > 1;
-    const namespace = isStoreNamespaced ? `${action.type.split("/")[0]}/` : "";
+    const namespace = isStoreNamespaced ? getNamespace(action.type) : "";
 
     switch (action.type) {
       case `${namespace}${REDO}`:


### PR DESCRIPTION
In my store, I have a module called "foo" which itself has a module called "bar". (These are just example names, of course.) I found that when I tried to use undo-redo-vuex on "bar", that it wouldn't work. A mutation in "bar" would set "canUndo" in "foo".

I think the way we compute the namespace in `subscribe` and `subscribeAction` is wrong. This fixes it in my case, but I've never worked in typescript, and am a novice in javascript. Also, I couldn't get your tests to run.

Feel free to take this, or let me know if I can improve it. Thanks!