### PR TITLE
fix stack trace: class constructor cannot be invoked without 'new'

### DIFF
--- a/src/undo.ts
+++ b/src/undo.ts
@@ -85,7 +85,7 @@ export default ({
         mutation.type,
         Array.isArray(mutation.payload)
           ? [...mutation.payload]
-          : mutation.payload.constructor(mutation.payload)
+          : new mutation.payload.constructor(mutation.payload)
       );
 
       // Check if there is an undo callback action


### PR DESCRIPTION
I got a stack trace in undo-redo-vuex, and this seems to fix it. Let me know if it needs any improvements.
Thanks!